### PR TITLE
Fix default VMC port for node-based plugin.

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   build:
     name: Assembling artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Note, to satisfy the asset library we need to make sure our zip files have a root folder
     # this is why we checkout into demo/godot_vmc_tracker
     # and build plugin/godot_vmc_tracker
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: demo/godot_vmc_tracker
       - name: Create Godot VMC Tracker plugin
@@ -29,13 +29,13 @@ jobs:
           rm -rf demo/godot_vmc_tracker/.git
           rm -rf demo/godot_vmc_tracker/.github
       - name: Create Godot VMC Tracker library artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: godot_vmc_tracker
           path: |
             plugin
       - name: Create Godot VMC Tracker demo artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: godot_vmc_tracker_demo
           path: |

--- a/.github/workflows/gdlint-on-push.yml
+++ b/.github/workflows/gdlint-on-push.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10' 
       - name: Install Dependencies

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Official releases are tagged and can be found [here](https://github.com/Malcolmn
 The following branches are in active development:
 |  Branch   |  Description                  |  Godot version   |
 |-----------|-------------------------------|------------------|
-|  master   | Current development branch    |  Godot 4.3-dev6+ |
+|  master   | Current development branch    |  Godot 4.3       |
 
 
 ## Overview

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,6 @@
+# 1.3.0
+- Fix default port
+
 # 1.2.0
 - Updated for changes to XR Tracker names and hierarchy
 

--- a/addons/godot_vmc_tracker/vmc_tracker.gd
+++ b/addons/godot_vmc_tracker/vmc_tracker.gd
@@ -19,7 +19,7 @@ extends Node
 @export_enum("Free", "Calibrate", "Locked") var position_mode : int = 0
 
 ## UDP listener port
-@export var udp_listener_port : int = 7004
+@export var udp_listener_port : int = 39539
 
 
 # Tracker source


### PR DESCRIPTION
This PR fixes issue #10. Additionally it updates some of the pipeline tools due to deprecation.